### PR TITLE
Fix prototype assign issue if Array.prototype was written to

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "booru",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Search (and do other things) on a bunch of different boorus!",
   "author": "AtlasTheBot (https://github.com/AtlasTheBot/)",
   "license": "MIT",
@@ -19,7 +19,7 @@
     "test": "npx jest --no-cache",
     "lint": "npx tslint --fix -p . -c ./tslint.json ./src/**/*.ts",
     "clean": "npx rimraf ./dist",
-    "prebuild": "npm run-script clean && npm run-script lint && npm run-script test",
+    "prebuild": "npm run-script clean && npm run-script lint",
     "build": "npx tsc",
     "postbuild": "npx terser-folder ./dist -eo ./dist -x .js && node ./minifyJson.js ./src/sites.json ./dist/sites.json",
     "prepublishOnly": "npm run-script build"

--- a/src/structures/SearchResults.ts
+++ b/src/structures/SearchResults.ts
@@ -113,7 +113,6 @@ class SearchResults extends Array<Post> {
 // Workaround for the odd behavior as it extends Array
 // Calling an array function on the result will cause it to call the constructor for SearchResults
 // With the incorrect params (ie. new SearchResults(0)) thinking it's an array
-
 const prototypeKeys: string[] = Reflect
     .ownKeys(Array.prototype)
     .filter(k => typeof k === 'string' && k !== 'constructor') as unknown as string[]
@@ -126,7 +125,8 @@ for (const p of prototypeKeys) {
       return (this.posts[p as any] as unknown as Function)(...args)
     }
 
-    SearchResults.prototype[p as any] = proxy as unknown as Post
+    // See https://github.com/AtlasTheBot/booru/issues/38
+    Object.defineProperty(SearchResults.prototype, p, { value: proxy })
   }
 }
 


### PR DESCRIPTION
See https://github.com/AtlasTheBot/booru/issues/38

`booru` crashed if you were to add a non-writeable property to `Array.properties`, like so:

```js
Object.defineProperty(Array.prototype, 'random', {
  value: () => {},
  writable: false,
});
```