### PR TITLE
R34 endpoint

### DIFF
--- a/src/sites.json
+++ b/src/sites.json
@@ -112,7 +112,7 @@
     "random": false
   },
   "rule34.xxx": {
-    "domain": "rule34.xxx",
+    "domain": "api.rule34.xxx",
     "aliases": [
       "r34",
       "rule34"


### PR DESCRIPTION
api endpoint change for r34xxx, old URL is being forwarded. 