### PR TITLE
fix: dont parse null directory

### DIFF
--- a/src/structures/Post.ts
+++ b/src/structures/Post.ts
@@ -20,7 +20,7 @@ const common = deprecate(() => {
 function parseImageUrl(url: string, data: any, booru: Booru): string | null {
   // If the image's file_url is *still* undefined or the source is empty or it's deleted
   // Thanks danbooru *grumble grumble*
-  if (!url || url.trim() === '' || data.is_deleted) {
+  if (!url || url.trim() === '' || data.is_deleted || !data.directory) {
     return null
   }
 

--- a/src/structures/Post.ts
+++ b/src/structures/Post.ts
@@ -20,7 +20,7 @@ const common = deprecate(() => {
 function parseImageUrl(url: string, data: any, booru: Booru): string | null {
   // If the image's file_url is *still* undefined or the source is empty or it's deleted
   // Thanks danbooru *grumble grumble*
-  if (!url || url.trim() === '' || data.is_deleted || !data.directory) {
+  if (!url || url.trim() === '' || data.is_deleted || data.directory === null) {
     return null
   }
 


### PR DESCRIPTION
realbooru api is not always update, that directory value said null but actually not
https://realbooru.com/index.php?page=dapi&s=post&q=index&tags=webm&json=1

rather than misleading like this, better to reject them
![Screenshot_413](https://user-images.githubusercontent.com/12372481/160055509-f7e08657-40f7-4db3-bb3d-78c66a5c424f.png)
