### PR TITLE
data.tags.split fix

### DIFF
--- a/src/structures/Post.ts
+++ b/src/structures/Post.ts
@@ -80,10 +80,13 @@ function getTags(data: any): string[] {
     )
   } else if (data.tags) {
     tags = data.tags.split(' ')
-  } else {
+  } else if(data.tag_string){
     tags = data.tag_string
       .split(' ')
       .map((v: string): string => v.replace(/,/g, '').replace(/ /g, '_'))
+  }
+  else{
+    return [];
   }
 
   return tags.filter((v: string) => v !== '')


### PR DESCRIPTION
Tags is empty string:
> https://konachan.com/post.json?tags=id:38805

Example:
 `const results = await Booru.search("konac", "id:38805");`

 Then throw error:
> TypeError: Cannot read properties of undefined (reading 'split')
    at getTags (/usr/src/node_modules/booru/dist/structures/Post.js:1:900)
    at new Post (/usr/src/node_modules/booru/dist/structures/Post.js:1:2165)
    at /usr/src/node_modules/booru/dist/boorus/Booru.js:1:2633
    at Array.map (<anonymous>)
    at Booru.parseSearchResult (/usr/src/node_modules/booru/dist/boorus/Booru.js:1:2625)
    at Booru.search (/usr/src/node_modules/booru/dist/boorus/Booru.js:1:927)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)...