### PR TITLE
Fix gelbooru returning wrong creation date

### DIFF
--- a/src/structures/Post.ts
+++ b/src/structures/Post.ts
@@ -262,6 +262,8 @@ export default class Post {
       )
     } else if (typeof data.created_at === 'number') {
       this.createdAt = new Date(data.created_at * 1000)
+    } else if (typeof data.created_at === 'string') {
+      this.createdAt = new Date(data.created_at)
     } else if (typeof data.change === 'number') {
       this.createdAt = new Date(data.change * 1000)
     } else {


### PR DESCRIPTION
It was returning the `change` date before. This makes it so it first checks if the `created_at` value is a string before checking for the `change` date.