### PR TITLE
Copy tags argument so it's not modified

### DIFF
--- a/src/boorus/Booru.ts
+++ b/src/boorus/Booru.ts
@@ -81,6 +81,14 @@ export class Booru {
     this.credentials = credentials
   }
 
+  protected normalizeTags(tags: string | string[]): string[] {
+    if (!Array.isArray(tags)) {
+      return [tags]
+    } else {
+      return tags.slice();
+    }
+  }
+
   /**
    * Search for images on this booru
    * @param {String|String[]} tags The tag(s) to search for
@@ -97,9 +105,10 @@ export class Booru {
     }: SearchParameters = {},
   ): Promise<SearchResults> {
     const fakeLimit: number = random && !this.site.random ? 100 : 0
+    const tagArray = this.normalizeTags(tags);
 
     try {
-      const searchResult = await this.doSearchRequest(tags, {
+      const searchResult = await this.doSearchRequest(tagArray, {
         limit,
         random,
         page,
@@ -107,7 +116,7 @@ export class Booru {
       })
       return this.parseSearchResult(searchResult, {
         fakeLimit,
-        tags,
+        tags: tagArray,
         limit,
         random,
         page,
@@ -147,7 +156,7 @@ export class Booru {
    * @return {Promise<Object>}
    */
   protected async doSearchRequest(
-    tags: string[] | string,
+    tags: string[],
     {
       uri = null,
       limit = 1,
@@ -155,8 +164,6 @@ export class Booru {
       page = 0,
     }: InternalSearchParameters = {},
   ): Promise<any> {
-    if (!Array.isArray(tags)) tags = [tags]
-
     // Used for random on sites without order:random
     let fakeLimit: number | undefined
 
@@ -290,10 +297,6 @@ export class Booru {
 
     if (tags === undefined) {
       tags = []
-    }
-
-    if (!Array.isArray(tags)) {
-      tags = [tags]
     }
 
     if (!showUnavailable) {

--- a/src/boorus/Derpibooru.ts
+++ b/src/boorus/Derpibooru.ts
@@ -31,27 +31,25 @@ export default class Derpibooru extends Booru {
     tags: string[] | string,
     { limit = 1, random = false, page = 0 }: SearchParameters = {},
   ): Promise<SearchResults> {
-    if (!Array.isArray(tags)) {
-      tags = [tags]
-    }
+    var tagArray = this.normalizeTags(tags);
 
     // For any image, you must supply *
-    if (tags[0] === undefined) {
-      tags[0] = '*'
+    if (tagArray[0] === undefined) {
+      tagArray[0] = '*'
     }
 
     // Derpibooru offsets the pages by 1
     page += 1
 
     const uri =
-      this.getSearchUrl({ tags, limit, page }) +
+      this.getSearchUrl({ tags: tagArray, limit, page }) +
       (random && this.site.random === 'string' ? `&${this.site.random}` : '') +
       (this.credentials ? `&key=${this.credentials.token}` : '')
 
     return super
-      .doSearchRequest(tags, { limit, random, page, uri })
+      .doSearchRequest(tagArray, { limit, random, page, uri })
       .then((r) =>
-        super.parseSearchResult(r, { fakeLimit: 0, tags, limit, random, page }),
+        super.parseSearchResult(r, { fakeLimit: 0, tags: tagArray, limit, random, page }),
       )
       .catch((e) => Promise.reject(new BooruError(e)))
   }

--- a/src/structures/InternalSearchParameters.ts
+++ b/src/structures/InternalSearchParameters.ts
@@ -15,5 +15,5 @@ export default interface InternalSearchParameters extends SearchParameters {
   /** If `order:random` should be faked */
   fakeLimit?: number
   /** The tags used in the search */
-  tags?: string[] | string
+  tags?: string[]
 }


### PR DESCRIPTION
I was passing the `tags` array from this object into `search` with `random: true` periodically and noticed `order:random` was being appended each time. With unauthenticated Danbooru, this quickly leads to hitting the tag limit.

```
[17.03.2024 18:07.02.955] [LOG]   {
  weight: 1,
  site: 'danbooru.donmai.us',
  tags: [ 'hatsune_miku', 'rating:general' ]
}

...

[17.03.2024 18:07.20.369] [LOG]   {
  weight: 1,
  site: 'danbooru.donmai.us',
  tags: [ 'hatsune_miku', 'rating:general', 'order:random' ]
}
[17.03.2024 18:07.20.786] [ERROR] ERROR: Getting posts BooruError: Received HTTP 422 from booru: 'PostQuery::TagLimitError'

...

[17.03.2024 18:07.25.787] [LOG]   {
  weight: 1,
  site: 'danbooru.donmai.us',
  tags: [ 'hatsune_miku', 'rating:general', 'order:random', 'order:random' ]
}
[17.03.2024 18:07.25.932] [ERROR] ERROR: Getting posts BooruError: Received HTTP 422 from booru: 'PostQuery::TagLimitError'
```

This could be worked around easily by passing in a copy of `tags` into `search`, but I'd like to contribute some features, so this seemed like a good place to start.

I changed `search` to copy the `tags` array instead of modifying it directly. Other changes were prompted by the typescript compiler and trying to guess what it wanted. This is my very first time doing anything typescript, so if there's something wrong here, that's why.