### PR TITLE
Add getPostCount and support for robust manual pagination

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -116,6 +116,37 @@ export function searchURI(
   return `http${site.insecure ? '' : 's'}://${site.domain}${site.api.search}${query}`
 }
 
+/**
+ * Create a full uri to search with
+ *
+ * @private
+ * @param {string} domain The domain to search
+ * @param {Site} site The site to search
+ * @param {string[]} [tags=[]] The tags to search for
+ * @param {number} [limit=100] The limit for images to return
+ * @param {number} [page=0] The page to get
+ * @param {BooryCredentials} [credentials] The credentials to use for the search, appended to the querystring
+ */
+export function postCountURI(
+    site: Site,
+    tags: string[] = [],
+    limit = 1,
+    credentials: BooruCredentials = {},
+): string {
+  const query = querystring(
+      {
+        [site.tagQuery]: expandTags(tags),
+        limit,
+        ...credentials,
+      },
+      {
+        arrayJoin: site.tagJoin,
+      },
+  )
+
+  return `http${site.insecure ? '' : 's'}://${site.domain}${site.api.postCount}${query}`
+}
+
 export function tagListURI(
   site: Site,
   limit = 100,

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -128,20 +128,20 @@ export function searchURI(
  * @param {BooryCredentials} [credentials] The credentials to use for the search, appended to the querystring
  */
 export function postCountURI(
-    site: Site,
-    tags: string[] = [],
-    limit = 1,
-    credentials: BooruCredentials = {},
+  site: Site,
+  tags: string[] = [],
+  limit = 1,
+  credentials: BooruCredentials = {},
 ): string {
   const query = querystring(
-      {
-        [site.tagQuery]: expandTags(tags),
-        limit,
-        ...credentials,
-      },
-      {
-        arrayJoin: site.tagJoin,
-      },
+    {
+      [site.tagQuery]: expandTags(tags),
+      limit,
+      ...credentials,
+    },
+    {
+      arrayJoin: site.tagJoin,
+    },
   )
 
   return `http${site.insecure ? '' : 's'}://${site.domain}${site.api.postCount}${query}`

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -6,11 +6,10 @@
 import { XMLParser } from 'fast-xml-parser'
 import { type AnySite, BooruError, sites } from './Constants'
 
-
 export interface ParseBooruResult {
-    posts: object[]
-    count: number
-    offset: number
+  posts: object[]
+  count: number
+  offset: number
 }
 
 /**
@@ -46,8 +45,8 @@ interface XMLPage {
 interface XMLPosts {
   post?: any[]
   tag?: any
-  count?: number,
-  offset?: number,
+  count?: number
+  offset?: number
 }
 
 interface XMLTags {
@@ -110,20 +109,22 @@ export function jsonifyPosts(xml: string): ParseBooruResult {
   let extractedPosts: object[] = []
 
   if (data.posts.post) {
-    extractedPosts = data.posts.post;
+    extractedPosts = data.posts.post
   }
 
   if (data.posts.tag) {
-    extractedPosts = Array.isArray(data.posts.tag) ? data.posts.tag : [data.posts.tag]
+    extractedPosts = Array.isArray(data.posts.tag)
+      ? data.posts.tag
+      : [data.posts.tag]
   }
 
   const count = Number(data.posts.count) || 0
-    const offset = Number(data.posts.offset) || 0
+  const offset = Number(data.posts.offset) || 0
 
-  return  {
+  return {
     posts: extractedPosts,
     count,
-    offset
+    offset,
   }
 }
 

--- a/src/boorus/Booru.ts
+++ b/src/boorus/Booru.ts
@@ -4,7 +4,13 @@
  */
 
 import { fetch } from 'undici'
-import {BooruError, defaultOptions, postCountURI, searchURI, tagListURI} from '../Constants'
+import {
+  BooruError,
+  defaultOptions,
+  postCountURI,
+  searchURI,
+  tagListURI,
+} from '../Constants'
 import type InternalSearchParameters from '../structures/InternalSearchParameters'
 import Post from '../structures/Post'
 import type SearchParameters from '../structures/SearchParameters'
@@ -143,29 +149,28 @@ export class Booru {
     }
   }
 
-    /**
-     * Gets the total number of posts for a specific tag or tag combination
-     * @param {String|String[]} tags The tag(s) to search for
-     * @return {Promise<number>} The total number of posts
-     */
-    public async getPostCount(tags: string | string[]): Promise<number> {
-        const tagArray = this.normalizeTags(tags)
+  /**
+   * Gets the total number of posts for a specific tag or tag combination
+   * @param {String|String[]} tags The tag(s) to search for
+   * @return {Promise<number>} The total number of posts
+   */
+  public async getPostCount(tags: string | string[]): Promise<number> {
+    const tagArray = this.normalizeTags(tags)
 
-        try {
-          const postCountResult = await this.doPostCountRequest(tagArray, {
-            limit: 1,
-          })
+    try {
+      const postCountResult = await this.doPostCountRequest(tagArray, {
+        limit: 1,
+      })
 
-          return postCountResult
-        } catch (err) {
-          if (err instanceof Error) {
-            throw new BooruError(err)
-          }
+      return postCountResult
+    } catch (err) {
+      if (err instanceof Error) {
+        throw new BooruError(err)
+      }
 
-          throw err
-        }
-
+      throw err
     }
+  }
 
   /**
    * Gets the url you'd see in your browser from a post id for this booru
@@ -323,23 +328,18 @@ export class Booru {
    * @return {Promise<Object>}
    */
   protected async doPostCountRequest(
-      tags: string[],
-      {
-        uri = null,
-        limit = 1,
-      }: InternalSearchParameters = {},
+    tags: string[],
+    { uri = null, limit = 1 }: InternalSearchParameters = {},
   ): Promise<number> {
     let searchTags = tags.slice()
 
     if (this.site.defaultTags) {
       searchTags = searchTags.concat(
-          this.site.defaultTags.filter((v) => !searchTags.includes(v)),
+        this.site.defaultTags.filter((v) => !searchTags.includes(v)),
       )
     }
 
-    const fetchuri =
-        uri ??
-        this.getPostCountUrl({ tags: searchTags, limit })
+    const fetchuri = uri ?? this.getPostCountUrl({ tags: searchTags, limit })
 
     try {
       const response = await resolvedFetch(fetchuri, defaultOptions)
@@ -349,7 +349,7 @@ export class Booru {
         const body = await response.clone().text()
         if (body.includes('cf-browser-verification')) {
           throw new BooruError(
-              "Received a CloudFlare browser verification request. Can't proceed.",
+            "Received a CloudFlare browser verification request. Can't proceed.",
           )
         }
       }
@@ -358,39 +358,42 @@ export class Booru {
 
       if (!response.ok) {
         throw new BooruError(
-            `Received HTTP ${response.status} ` +
+          `Received HTTP ${response.status} ` +
             `from booru: '${
-                (data as any).error ??
-                (data as any).message ??
-                JSON.stringify(data)
+              (data as any).error ??
+              (data as any).message ??
+              JSON.stringify(data)
             }'`,
         )
       }
 
-      const postCountType = this.site.postCountType;
+      const postCountType = this.site.postCountType
 
-      return this.getPostCountNumber(postCountType, data);
+      return this.getPostCountNumber(postCountType, data)
     } catch (err) {
       if ((err as any).type === 'invalid-json') return 0
       throw err
     }
   }
 
-  private getPostCountNumber(postCountType: "json" | "xml" | "derpi", data: string) {
+  private getPostCountNumber(
+    postCountType: 'json' | 'xml' | 'derpi',
+    data: string,
+  ) {
     if (postCountType === 'json') {
-      return (tryParseJSON(data) as any).counts.posts;
+      return (tryParseJSON(data) as any).counts.posts
     }
     if (postCountType === 'derpi') {
-      return (tryParseJSON(data) as any).total;
+      return (tryParseJSON(data) as any).total
     }
     if (postCountType === 'xml') {
-      console.log(this.site.domain);
+      console.log(this.site.domain)
       const jsonData = jsonifyPosts(data)
       if (jsonData.count !== undefined) {
         return jsonData.count
       }
     }
-    return -1;
+    return -1
   }
 
   /**
@@ -418,12 +421,11 @@ export class Booru {
    * @returns A URL to search the booru
    */
   getPostCountUrl({
-                 tags = [],
-                 limit = 1,
-               }: Partial<SearchUrlParams> = {}): string {
+    tags = [],
+    limit = 1,
+  }: Partial<SearchUrlParams> = {}): string {
     return postCountURI(this.site, tags, limit, this.credentials)
   }
-
 
   /**
    * Generates a URL to get a list of tags from the booru
@@ -544,7 +546,6 @@ export class Booru {
 
     return new TagListResults(tags, { limit, page }, this)
   }
-
 }
 
 export default Booru

--- a/src/boorus/Booru.ts
+++ b/src/boorus/Booru.ts
@@ -387,7 +387,6 @@ export class Booru {
       return (tryParseJSON(data) as any).total
     }
     if (postCountType === 'xml') {
-      console.log(this.site.domain)
       const jsonData = jsonifyPosts(data)
       if (jsonData.count !== undefined) {
         return jsonData.count

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,10 @@ export interface BooruSearch extends SearchParameters {
   credentials?: BooruCredentials
 }
 
+export interface BooruPostCountOptions {
+  credentials?: BooruCredentials
+}
+
 export interface BooruTagList extends TagListParameters {
   credentials?: BooruCredentials
 }
@@ -115,6 +119,46 @@ export function search(
   // This is ugly and a hack, I know this
   booruCache[rSite].credentials = credentials
   return booruCache[rSite].search(tags, { limit, random, page })
+}
+
+/**
+ * Gets the total number of posts for specific tags
+ * @param {String} site The site to search
+ * @param {String[]|String} [tags=[]] Tags to check the count for
+ * @param {BooruPostCountOptions} [options={}] The options (credentials)
+ * @return {Promise<number>} A promise with the total number of posts
+ *
+ * @example
+ * ```
+ * const Booru = require('booru')
+ * // Returns the total amount of posts for 'cat' on e926
+ * const count = await Booru.postCount('e926', ['cat'])
+ * ```
+ */
+export function postCount(
+    site: string,
+    tags: string[] | string = [],
+    { credentials = {} }: BooruPostCountOptions = {},
+): Promise<number> {
+  const rSite = resolveSite(site)
+
+  if (rSite === null) {
+    throw new BooruError('Site not supported')
+  }
+
+  if (!Array.isArray(tags) && typeof tags !== 'string') {
+    throw new BooruError('`tags` should be an array or string')
+  }
+
+  const booruSite = new Site(sites[rSite])
+
+  if (!booruCache[rSite]) {
+    booruCache[rSite] = booruFrom(booruSite, credentials)
+  }
+
+  booruCache[rSite]!.credentials = credentials
+
+  return booruCache[rSite]!.getPostCount(tags)
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,9 +136,9 @@ export function search(
  * ```
  */
 export function postCount(
-    site: string,
-    tags: string[] | string = [],
-    { credentials = {} }: BooruPostCountOptions = {},
+  site: string,
+  tags: string[] | string = [],
+  { credentials = {} }: BooruPostCountOptions = {},
 ): Promise<number> {
   const rSite = resolveSite(site)
 
@@ -156,9 +156,9 @@ export function postCount(
     booruCache[rSite] = booruFrom(booruSite, credentials)
   }
 
-  booruCache[rSite]!.credentials = credentials
+  booruCache[rSite].credentials = credentials
 
-  return booruCache[rSite]!.getPostCount(tags)
+  return booruCache[rSite]?.getPostCount(tags)
 }
 
 /**

--- a/src/sites.json
+++ b/src/sites.json
@@ -41,7 +41,8 @@
     "api": {
       "search": "/index.php?page=dapi&s=post&q=index&json=1&",
       "postView": "/post/show/",
-      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&"
+      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&",
+      "postCount": "/index.php?page=dapi&s=post&q=index&"
     },
     "paginate": "pid",
     "random": false
@@ -57,9 +58,11 @@
     "api": {
       "search": "/posts.json?",
       "postView": "/posts/",
-      "tagList": "/tags.json?"
+      "tagList": "/tags.json?",
+      "postCount": "/counts/posts.json?"
     },
-    "random": true
+    "random": true,
+    "postCountType": "json"
   },
   "konachan.com": {
     "domain": "konachan.com",
@@ -72,7 +75,8 @@
     "api": {
       "search": "/post.json?",
       "postView": "/post/show/",
-      "tagList": "/tag.json?"
+      "tagList": "/tag.json?",
+      "postCount": "/post.xml/?"
     },
     "random": true
   },
@@ -87,7 +91,8 @@
     "api": {
       "search": "/post.json?",
       "postView": "/post/show/",
-      "tagList": "/tag.json?"
+      "tagList": "/tag.json?",
+      "postCount": "/post.xml/?"
     },
     "random": true
   },
@@ -102,7 +107,8 @@
     "api": {
       "search": "/post.json?",
       "postView": "/post/show/",
-      "tagList": "/tag.json?"
+      "tagList": "/tag.json?",
+      "postCount": "/post.xml/?"
     },
     "random": true
   },
@@ -117,7 +123,8 @@
     "api": {
       "search": "/index.php?page=dapi&s=post&q=index&json=1&",
       "postView": "/index.php?page=post&s=view&json=1&id=",
-      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&"
+      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&",
+      "postCount": "/index.php?page=dapi&s=post&q=index&"
     },
     "paginate": "pid",
     "random": false
@@ -132,7 +139,8 @@
     "api": {
       "search": "/index.php?page=dapi&s=post&q=index&json=1&",
       "postView": "/index.php?page=post&s=view&json=1&id=",
-      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&"
+      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&",
+      "postCount": "/index.php?page=dapi&s=post&q=index&"
     },
     "paginate": "pid",
     "random": false
@@ -148,7 +156,8 @@
     "api": {
       "search": "/index.php?page=dapi&s=post&q=index&json=1&",
       "postView": "/index.php?page=post&s=view&json=1&id=",
-      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&"
+      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&",
+      "postCount": "/index.php?page=dapi&s=post&q=index&"
     },
     "paginate": "pid",
     "random": false
@@ -179,7 +188,8 @@
     "api": {
       "search": "/index.php?page=dapi&s=post&q=index&json=1&",
       "postView": "/index.php?page=post&s=view&json=1&id=",
-      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&"
+      "tagList": "/index.php?page=dapi&s=tag&q=index&json=1&",
+      "postCount": "/index.php?page=dapi&s=post&q=index&"
     },
     "paginate": "pid",
     "random": false
@@ -194,7 +204,8 @@
     "nsfw": true,
     "api": {
       "search": "/api/danbooru/find_posts?",
-      "postView": "/post/view/"
+      "postView": "/post/view/",
+      "postCount": "/api/danbooru/find_posts?"
     },
     "random": false
   },
@@ -210,11 +221,13 @@
     "nsfw": true,
     "api": {
       "search": "/api/v1/json/search/images?",
-      "postView": "/images/"
+      "postView": "/images/",
+      "postCount": "/api/v1/json/search/images?&per_page=1&"
     },
     "tagQuery": "q",
     "tagJoin": ",",
-    "random": "sf=random"
+    "random": "sf=random",
+    "postCountType": "derpi"
   },
   "realbooru.com": {
     "domain": "realbooru.com",

--- a/src/structures/InternalSearchParameters.ts
+++ b/src/structures/InternalSearchParameters.ts
@@ -3,7 +3,7 @@
  * @module Structures
  */
 
-import { BooruCredentials } from '../boorus/Booru'
+import type { BooruCredentials } from '../boorus/Booru'
 import type SearchParameters from './SearchParameters'
 
 /**

--- a/src/structures/Site.ts
+++ b/src/structures/Site.ts
@@ -41,7 +41,7 @@ export default class Site {
   constructor(data: SiteInfo) {
     this.domain = data.domain
     this.type = data.type ?? 'json'
-    this.postCountType = data.postCountType ?? "xml";
+    this.postCountType = data.postCountType ?? 'xml'
     this.aliases = data.aliases ?? []
     this.nsfw = data.nsfw
     this.api = data.api ?? {}

--- a/src/structures/Site.ts
+++ b/src/structures/Site.ts
@@ -13,7 +13,9 @@ export default class Site {
   /** The domain of the Site (the "google.com" part of "https://google.com/foo") */
   public domain: string
   /** The type of this site (json/xml/derpi) */
-  public type: string
+  type: 'json' | 'xml' | 'derpi'
+  /** The type of post count this site uses, if any */
+  postCountType: 'json' | 'xml' | 'derpi'
   /** The aliases of this site */
   public aliases: string[]
   /** If this site serves NSFW posts or not */
@@ -39,6 +41,7 @@ export default class Site {
   constructor(data: SiteInfo) {
     this.domain = data.domain
     this.type = data.type ?? 'json'
+    this.postCountType = data.postCountType ?? "xml";
     this.aliases = data.aliases ?? []
     this.nsfw = data.nsfw
     this.api = data.api ?? {}

--- a/src/structures/SiteApi.ts
+++ b/src/structures/SiteApi.ts
@@ -16,5 +16,4 @@ export default interface SiteApi {
   tagList?: string
   /** The path to retrieve the count of posts with tags */
   postCount?: string
-
 }

--- a/src/structures/SiteApi.ts
+++ b/src/structures/SiteApi.ts
@@ -14,4 +14,7 @@ export default interface SiteApi {
   postView: string
   /** The path to retrieve a list of tags */
   tagList?: string
+  /** The path to retrieve the count of posts with tags */
+  postCount?: string
+
 }

--- a/src/structures/SiteInfo.ts
+++ b/src/structures/SiteInfo.ts
@@ -14,7 +14,9 @@ export default interface SiteInfo {
   /** The domain of the Site (the "google.com" part of "https://google.com/foo") */
   domain: string
   /** The type of this site (json/xml/derpi) */
-  type: string
+  type: 'json' | 'xml' | 'derpi'
+  /** The type of post count this site uses, if any */
+  postCountType: 'json' | 'xml' | 'derpi'
   /** The aliases of this site */
   aliases: string[]
   /** If this site serves NSFW posts or not */


### PR DESCRIPTION
Yo! I noticed that the native `random: true` option is pretty flaky on some sites. For example, Danbooru often throws a HTTP 500 (`The database timed out running your query`) when trying to randomize a large set of results. Also, the randomness on some other sites felt a bit limited (only shuffling the first few results).

To fix this, I added endpoints and functions to retrieve the **total post count** for supported sites. This allows for a much more robust "client-side randomness" using pagination.

**How to use it now:**
```typescript
const totalPosts = await client.getPostCount(tags);
// Calculate max pages based on your limit (e.g., 100)
// Failsafe at 999 because many Boorus won't let you paginate deeper
const maxPages = Math.min(Math.ceil(totalPosts / 100), 999);
const randomPage = Math.floor(Math.random() * maxPages);

// Fetch a stable, non-random page
const results = await client.search(tags, { limit: 100, random: false, page: randomPage });
// Then just pick a random index from the results array!
```

**Site-specific notes from my testing:**
* **e621.net / e926.net:** Couldn't find a reliable endpoint for post count with specific tags, so they currently don't support this specific feature.
* **realbooru.com:** Their API is currently "broken indefinitely" according to their own error messages, so I skipped it.
* **tbib.org:** Seems to have some aggressive IP blocking/Cloudflare issues (at least for me), so needs further checking.

I've been using this logic in a private project with a Redis cache and it works beautifully without ever hitting those nasty 500 timeouts.

**One final note:** 
I noticed the existing tests were already failing before I started my changes (I swear!). I tried to keep my additions as non-breaking as possible.

Let me know if you want me to tweak anything!